### PR TITLE
Build static marketing portfolio site

### DIFF
--- a/agence-propulsion.html
+++ b/agence-propulsion.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Agence Propulsion – Compétitions académiques</title>
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="project-page">
+    <button class="menu-toggle hover-scale" type="button" data-menu-toggle aria-expanded="false" aria-controls="project-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span>Menu</span>
+    </button>
+
+    <nav class="project-menu" id="project-menu" data-project-menu>
+        <ul>
+            <li><a class="hover-scale" href="index.html">Accueil</a></li>
+            <li><a class="hover-scale" href="asics.html">Asics – Stratégie numérique</a></li>
+            <li><a class="hover-scale" href="agence-propulsion.html">Agence Propulsion – Compétitions académiques</a></li>
+            <li><a class="hover-scale" href="cowansville-economique.html">Cowansville Économique – Lancement d’initiative</a></li>
+            <li><a class="hover-scale" href="brasser-pour-donner.html">Brasser pour donner – Commercialisation</a></li>
+            <li><a class="hover-scale" href="analyse-familiprix.html">Analyse Familiprix – Campagne publicitaire</a></li>
+        </ul>
+    </nav>
+
+    <div class="fixed-actions">
+        <a class="action-link hover-scale" href="assets/docs/CV-Sebastien-Bouchard.pdf" target="_blank" rel="noopener">CV</a>
+        <a class="action-link hover-scale" href="https://www.instagram.com/seb_bouch33/" target="_blank" rel="noopener">Instagram</a>
+        <a class="action-link hover-scale" href="https://www.linkedin.com/in/s%C3%A9bastien-bouchard-1329b321a/" target="_blank" rel="noopener">LinkedIn</a>
+    </div>
+
+    <main class="project-content">
+        <header class="project-header">
+            <div>
+                <span class="tag">Gestion d’agence</span>
+                <h1>Agence Propulsion</h1>
+                <p class="lead">Agence propulsée par l’énergie d’une équipe étudiante multidisciplinaire. Notre mission : se démarquer lors de compétitions marketing majeures en proposant des stratégies créatives et mesurables pour de véritables clients.</p>
+            </div>
+            <div class="project-meta">
+                <span class="tag">Coaching</span>
+                <span class="tag">Planification</span>
+                <span class="tag">Analytique</span>
+            </div>
+        </header>
+
+        <section class="project-panels">
+            <article class="panel">
+                <h2>Reconnaissances</h2>
+                <p>Plusieurs podiums obtenus lors de la saison 2023-2024, dont une mention spéciale pour la stratégie numérique lors de la compétition Défi OSEntreprendre.</p>
+                <ul>
+                    <li>1<sup>re</sup> position – Campagne numérique créative.</li>
+                    <li>2<sup>e</sup> position – Stratégie d’acquisition de talents.</li>
+                    <li>Prix coup de cœur du jury pour la présentation.</li>
+                </ul>
+                <div class="media-grid">
+                    <div class="media-tile hover-scale">Moments en compétition</div>
+                    <div class="media-tile hover-scale">Mentorat &amp; coaching</div>
+                </div>
+            </article>
+
+            <article class="panel">
+                <h2>Cas Éconofitness</h2>
+                <p>Mandat visant à rehausser l’expérience numérique et à convertir les abonnements d’essai en adhésions complètes. L’équipe a proposé un plan de gamification, un parcours mobile optimisé et un calendrier d’activation sociale.</p>
+                <ul>
+                    <li>Cartographie du parcours membre sur 90 jours.</li>
+                    <li>Tests utilisateurs et ajustements UI/UX.</li>
+                    <li>Création d’indicateurs de performance et tableau de bord.</li>
+                </ul>
+                <div class="media-grid">
+                    <div class="media-tile hover-scale">Parcours membre</div>
+                    <div class="media-tile hover-scale">Activation mobile</div>
+                </div>
+            </article>
+
+            <article class="panel">
+                <h2>Cas Hydro-Québec</h2>
+                <p>Défi de sensibilisation à l’économie d’énergie auprès des jeunes adultes. Notre réponse : une campagne multiplateforme combinant contenus éducatifs et micro-influence.</p>
+                <ul>
+                    <li>Contenu social média adapté aux habitudes nocturnes.</li>
+                    <li>Planification de capsules vidéo interactives.</li>
+                    <li>Partenariats avec des créateurs spécialisés en écoresponsabilité.</li>
+                </ul>
+                <a class="primary-link hover-scale" href="https://example.com/agence-propulsion-cas-complets.pdf" target="_blank" rel="noopener">Cas complets</a>
+            </article>
+        </section>
+
+        <p class="footer-note">Projet réalisé avec l’Agence Propulsion – documentation détaillée disponible sur demande.</p>
+    </main>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/analyse-familiprix.html
+++ b/analyse-familiprix.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Analyse Familiprix – Campagne publicitaire</title>
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="project-page">
+    <button class="menu-toggle hover-scale" type="button" data-menu-toggle aria-expanded="false" aria-controls="project-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span>Menu</span>
+    </button>
+
+    <nav class="project-menu" id="project-menu" data-project-menu>
+        <ul>
+            <li><a class="hover-scale" href="index.html">Accueil</a></li>
+            <li><a class="hover-scale" href="asics.html">Asics – Stratégie numérique</a></li>
+            <li><a class="hover-scale" href="agence-propulsion.html">Agence Propulsion – Compétitions académiques</a></li>
+            <li><a class="hover-scale" href="cowansville-economique.html">Cowansville Économique – Lancement d’initiative</a></li>
+            <li><a class="hover-scale" href="brasser-pour-donner.html">Brasser pour donner – Commercialisation</a></li>
+            <li><a class="hover-scale" href="analyse-familiprix.html">Analyse Familiprix – Campagne publicitaire</a></li>
+        </ul>
+    </nav>
+
+    <div class="fixed-actions">
+        <a class="action-link hover-scale" href="assets/docs/CV-Sebastien-Bouchard.pdf" target="_blank" rel="noopener">CV</a>
+        <a class="action-link hover-scale" href="https://www.instagram.com/seb_bouch33/" target="_blank" rel="noopener">Instagram</a>
+        <a class="action-link hover-scale" href="https://www.linkedin.com/in/s%C3%A9bastien-bouchard-1329b321a/" target="_blank" rel="noopener">LinkedIn</a>
+    </div>
+
+    <main class="project-content">
+        <header class="project-header">
+            <div>
+                <span class="tag">Analyse publicitaire</span>
+                <h1>Analyse publicitaire Familiprix</h1>
+                <p class="lead">Décortiquer une campagne télé et numérique afin de comprendre comment l’émotion, la narration et la preuve sociale contribuent à la performance de la marque Familiprix.</p>
+            </div>
+            <div class="project-meta">
+                <span class="tag">Stratégie créative</span>
+                <span class="tag">UX</span>
+                <span class="tag">Contenu</span>
+            </div>
+        </header>
+
+        <section class="project-panels">
+            <article class="panel">
+                <h2>Observation principale</h2>
+                <p>La campagne met en vedette des moments de vie quotidienne empreints d’humour et de vulnérabilité. Cette tonalité permet de se distinguer dans un univers pharmaceutique souvent axé sur la rationalité.</p>
+                <p>Le slogan « Ne cherchez pas vos symptômes sur internet » positionne le pharmacien comme la ressource empathique et rassurante, tandis que la réalisation cinématographique humanise la marque.</p>
+                <div class="media-grid">
+                    <div class="media-tile hover-scale">Séquences vidéo clés</div>
+                    <div class="media-tile hover-scale">Analyse du slogan</div>
+                </div>
+            </article>
+
+            <article class="panel">
+                <h2>Analyse stratégique</h2>
+                <ul>
+                    <li>Identification du concept créatif : humour bienveillant et proximité.</li>
+                    <li>Décodage du parcours utilisateur sur le web et en succursale.</li>
+                    <li>Recommandations pour amplifier la prise de rendez-vous en ligne.</li>
+                </ul>
+                <p>Les recommandations incluent la création de micro-contenus pour les réseaux sociaux et l’intégration d’un module de clavardage pour améliorer la conversion.</p>
+            </article>
+
+            <article class="panel">
+                <h2>Livrables</h2>
+                <ul>
+                    <li>Grille d’évaluation de la campagne sur 5 axes.</li>
+                    <li>Storyboard annoté soulignant les moments d’émotion.</li>
+                    <li>Plan de tests utilisateurs pour les futures optimisations.</li>
+                </ul>
+                <a class="primary-link hover-scale" href="https://example.com/analyse-familiprix-detaillee.pdf" target="_blank" rel="noopener">Analyse détaillée</a>
+            </article>
+        </section>
+
+        <p class="footer-note">Analyse réalisée dans un contexte académique – mise à jour possible selon les prochaines campagnes Familiprix.</p>
+    </main>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/asics.html
+++ b/asics.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Projet ASICS – Stratégie numérique</title>
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="project-page">
+    <button class="menu-toggle hover-scale" type="button" data-menu-toggle aria-expanded="false" aria-controls="project-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span>Menu</span>
+    </button>
+
+    <nav class="project-menu" id="project-menu" data-project-menu>
+        <ul>
+            <li><a class="hover-scale" href="index.html">Accueil</a></li>
+            <li><a class="hover-scale" href="asics.html">Asics – Stratégie numérique</a></li>
+            <li><a class="hover-scale" href="agence-propulsion.html">Agence Propulsion – Compétitions académiques</a></li>
+            <li><a class="hover-scale" href="cowansville-economique.html">Cowansville Économique – Lancement d’initiative</a></li>
+            <li><a class="hover-scale" href="brasser-pour-donner.html">Brasser pour donner – Commercialisation</a></li>
+            <li><a class="hover-scale" href="analyse-familiprix.html">Analyse Familiprix – Campagne publicitaire</a></li>
+        </ul>
+    </nav>
+
+    <div class="fixed-actions">
+        <a class="action-link hover-scale" href="assets/docs/CV-Sebastien-Bouchard.pdf" target="_blank" rel="noopener">CV</a>
+        <a class="action-link hover-scale" href="https://www.instagram.com/seb_bouch33/" target="_blank" rel="noopener">Instagram</a>
+        <a class="action-link hover-scale" href="https://www.linkedin.com/in/s%C3%A9bastien-bouchard-1329b321a/" target="_blank" rel="noopener">LinkedIn</a>
+    </div>
+
+    <main class="project-content">
+        <header class="project-header">
+            <div>
+                <span class="tag">Marketing numérique</span>
+                <h1>ASICS – Campagne de performance</h1>
+                <p class="lead">Déploiement d’une stratégie numérique intégrée pour dynamiser la communauté de coureurs, nourrir les ventes e-commerce et aligner les recommandations créatives avec les objectifs d’affaires de la marque.</p>
+            </div>
+            <div class="project-meta">
+                <span class="tag">Analyse clientèle</span>
+                <span class="tag">Activation</span>
+                <span class="tag">SEO &amp; SEA</span>
+                <span class="tag">Communauté</span>
+            </div>
+        </header>
+
+        <section class="project-panels">
+            <article class="panel">
+                <h2>Constat &amp; insight</h2>
+                <p>À partir d’une recherche approfondie sur les habitudes numériques des coureurs, nous avons identifié des irritants liés à la fragmentation du parcours d’achat. L’analyse a révélé un besoin d’accompagnement personnalisé ainsi que d’inspiration concrète pour maintenir la motivation des athlètes.</p>
+                <p>En ciblant les segments « performeurs sociaux » et « explorateurs urbains », l’équipe a développé un positionnement valorisant l’expertise technique d’ASICS tout en humanisant les interactions.</p>
+                <div class="media-grid">
+                    <div class="media-tile hover-scale">Mapping clientèle</div>
+                    <div class="media-tile hover-scale">Insight &amp; tension</div>
+                </div>
+            </article>
+
+            <article class="panel">
+                <h2>Stratégie numérique</h2>
+                <p>Le plan numérique s’articule autour de trois axes : acquisition, conversion et fidélisation. Chaque axe est soutenu par une combinaison de tactiques média et de contenus pour renforcer la considération de la marque.</p>
+                <ul>
+                    <li>Campagnes SEO/SEA coordonnées sur les requêtes liées à la performance et au confort.</li>
+                    <li>Scénarios de communication A/B pour optimiser les messages selon les personas identifiés.</li>
+                    <li>Programme communautaire mettant en valeur les ambassadeurs locaux et l’entraînement collaboratif.</li>
+                </ul>
+                <div class="media-grid">
+                    <div class="media-tile hover-scale">Tunnel d’acquisition</div>
+                    <div class="media-tile hover-scale">Calendrier média</div>
+                    <div class="media-tile hover-scale">Plan de contenu</div>
+                </div>
+            </article>
+
+            <article class="panel">
+                <h2>Résultats attendus</h2>
+                <p>Les recommandations génèrent une expérience de marque cohérente du premier contact jusqu’au suivi post-achat. La stratégie mise sur des KPIs clairs : taux d’engagement de la communauté, croissance de la base CRM et valeur moyenne des paniers.</p>
+                <a class="primary-link hover-scale" href="https://example.com/projet-asics-detaille.pdf" target="_blank" rel="noopener">Projet détaillé</a>
+            </article>
+        </section>
+
+        <p class="footer-note">Projet académique présenté dans le cadre d’un mandat stratégique – visuels de référence fournis par l’équipe.</p>
+    </main>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,566 @@
+:root {
+    --bg-color: #fdfdfd;
+    --text-color: #101010;
+    --accent-color: #0f1e54;
+    --accent-alt: #d95763;
+    --card-bg: rgba(255, 255, 255, 0.86);
+    --grid-color: rgba(0, 0, 0, 0.06);
+    --panel-shadow: 0 18px 45px rgba(15, 30, 84, 0.12);
+    --transition-speed: 0.25s;
+    --max-content-width: 1100px;
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html, body {
+    height: 100%;
+}
+
+body {
+    font-family: "Poppins", "Helvetica Neue", Arial, sans-serif;
+    background-color: var(--bg-color);
+    background-image: radial-gradient(var(--grid-color) 1px, transparent 1px);
+    background-size: 26px 26px;
+    color: var(--text-color);
+    overflow-x: hidden;
+    line-height: 1.6;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:focus {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 3px;
+}
+
+.hover-scale {
+    transition: transform var(--transition-speed) ease, box-shadow var(--transition-speed) ease;
+    will-change: transform;
+}
+
+.hover-scale:hover,
+.hover-scale:focus-visible {
+    transform: scale(1.05);
+    box-shadow: 0 14px 40px rgba(0, 0, 0, 0.16);
+}
+
+button {
+    font: inherit;
+    border: none;
+    cursor: pointer;
+    background: none;
+}
+
+.menu-toggle {
+    position: fixed;
+    top: 1.6rem;
+    left: 1.6rem;
+    z-index: 1001;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.8rem 1.4rem;
+    border-radius: 999px;
+    background-color: var(--card-bg);
+    box-shadow: var(--panel-shadow);
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.menu-toggle span,
+.menu-toggle .menu-icon {
+    pointer-events: none;
+}
+
+.menu-icon {
+    position: relative;
+    width: 24px;
+    height: 2px;
+    background: var(--text-color);
+}
+
+.menu-icon::before,
+.menu-icon::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    width: 24px;
+    height: 2px;
+    background: var(--text-color);
+    transition: transform var(--transition-speed) ease;
+}
+
+.menu-icon::before {
+    top: -7px;
+}
+
+.menu-icon::after {
+    top: 7px;
+}
+
+.menu-toggle[aria-expanded="true"] .menu-icon {
+    background: transparent;
+}
+
+.menu-toggle[aria-expanded="true"] .menu-icon::before {
+    transform: translateY(7px) rotate(45deg);
+}
+
+.menu-toggle[aria-expanded="true"] .menu-icon::after {
+    transform: translateY(-7px) rotate(-45deg);
+}
+
+.fixed-actions {
+    position: fixed;
+    top: 1.6rem;
+    right: 1.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    z-index: 1000;
+}
+
+.action-link {
+    padding: 0.8rem 1.6rem;
+    border-radius: 999px;
+    background-color: var(--card-bg);
+    box-shadow: var(--panel-shadow);
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.project-menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    max-height: 0;
+    overflow: hidden;
+    background: rgba(253, 253, 253, 0.96);
+    backdrop-filter: blur(16px);
+    transition: max-height 0.45s ease;
+    z-index: 980;
+}
+
+.project-menu.is-open {
+    max-height: 100vh;
+    padding: 6.5rem 1.5rem 3rem;
+}
+
+.project-menu ul {
+    list-style: none;
+    max-width: 700px;
+    margin: 0 auto;
+    display: grid;
+    gap: 1rem;
+}
+
+.project-menu a {
+    display: inline-block;
+    padding: 1rem 1.6rem;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.85);
+    box-shadow: var(--panel-shadow);
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
+body.menu-open {
+    overflow: hidden;
+}
+
+.drag-container {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    cursor: grab;
+}
+
+.drag-container.is-dragging {
+    cursor: grabbing;
+}
+
+.drag-surface {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 1800px;
+    height: 1200px;
+    --offset-x: 0px;
+    --offset-y: 0px;
+    --zoom: 1;
+    transform-origin: 50% 50%;
+    transform: translate(calc(-50% + var(--offset-x, 0px)), calc(-50% + var(--offset-y, 0px))) scale(var(--zoom, 1));
+    transition: transform 0.1s ease-out;
+}
+
+.drag-hints {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    z-index: 1;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    color: rgba(16, 16, 16, 0.45);
+}
+
+.drag-hints .hint {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.drag-hints .hint::before {
+    font-size: 1.25rem;
+}
+
+.hint-up { grid-area: 1 / 1 / 2 / 3; align-items: flex-start; padding-top: 1.5rem; }
+.hint-down { grid-area: 2 / 1 / 3 / 3; align-items: flex-end; padding-bottom: 1.5rem; }
+.hint-left { grid-area: 1 / 1 / 3 / 2; justify-content: flex-start; padding-left: 1.5rem; }
+.hint-right { grid-area: 1 / 2 / 3 / 3; justify-content: flex-end; padding-right: 1.5rem; }
+
+.hint-up::before { content: "↑"; }
+.hint-down::before { content: "↓"; }
+.hint-left::before { content: "←"; }
+.hint-right::before { content: "→"; }
+
+.home-hero {
+    position: absolute;
+    top: 46%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 520px;
+    padding: 3.5rem 3rem;
+    border-radius: 28px;
+    background: linear-gradient(145deg, rgba(255,255,255,0.95), rgba(235,239,255,0.85));
+    box-shadow: var(--panel-shadow);
+    text-align: center;
+}
+
+.home-hero h1 {
+    font-size: clamp(2.6rem, 4vw, 4.4rem);
+    letter-spacing: -0.03em;
+    margin-bottom: 1rem;
+}
+
+.home-hero p {
+    text-transform: uppercase;
+    letter-spacing: 0.4em;
+    font-size: 0.9rem;
+    color: rgba(16, 16, 16, 0.7);
+}
+
+.projects-cloud {
+    position: absolute;
+    inset: 0;
+}
+
+
+.project-card {
+    position: absolute;
+    width: 300px;
+    min-height: 360px;
+    border-radius: 26px;
+    background: linear-gradient(160deg, rgba(255,255,255,0.94), rgba(226,234,255,0.85));
+    box-shadow: var(--panel-shadow);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    text-decoration: none;
+    color: inherit;
+}
+
+.project-visual {
+    margin: 0;
+    flex-shrink: 0;
+    height: 170px;
+    background: rgba(255,255,255,0.4);
+}
+
+.project-visual img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.project-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    padding: 1.6rem 1.6rem 1.4rem;
+    min-height: 160px;
+}
+
+.project-card h2 {
+    font-size: 1.5rem;
+    letter-spacing: -0.01em;
+}
+
+.project-card p {
+    font-size: 0.95rem;
+    color: rgba(16, 16, 16, 0.74);
+    line-height: 1.45;
+}
+
+.project-card::after {
+    content: "→";
+    margin: 0 1.6rem 1.6rem auto;
+    font-size: 1.6rem;
+    color: var(--accent-color);
+    transition: transform var(--transition-speed) ease;
+}
+
+.project-card:hover::after,
+.project-card:focus-visible::after {
+    transform: translateX(6px);
+}
+
+.project-card[data-project="asics"] { top: 14%; left: 18%; }
+.project-card[data-project="agence-propulsion"] { top: 24%; right: 16%; }
+.project-card[data-project="cowansville"] { bottom: 20%; left: 22%; }
+.project-card[data-project="brasser"] { bottom: 12%; right: 20%; }
+.project-card[data-project="familiprix"] { top: 68%; left: 58%; }
+
+main.project-content {
+    padding: 7rem 1.5rem 4rem;
+}
+
+.project-header {
+    max-width: var(--max-content-width);
+    margin: 0 auto 3.5rem;
+    display: grid;
+    gap: 2rem;
+}
+
+.project-header h1 {
+    font-size: clamp(2.4rem, 5vw, 4.5rem);
+    letter-spacing: -0.03em;
+}
+
+.project-header p.lead {
+    font-size: 1.1rem;
+    color: rgba(16, 16, 16, 0.74);
+    max-width: 620px;
+}
+
+.project-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.tag {
+    padding: 0.45rem 1rem;
+    border-radius: 999px;
+    background: rgba(15, 30, 84, 0.12);
+    font-size: 0.85rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.project-panels {
+    max-width: var(--max-content-width);
+    margin: 0 auto;
+    display: grid;
+    gap: 2rem;
+}
+
+.panel {
+    padding: 2.4rem;
+    border-radius: 28px;
+    background: var(--card-bg);
+    box-shadow: var(--panel-shadow);
+}
+
+.panel h2 {
+    font-size: 1.6rem;
+    margin-bottom: 1.1rem;
+}
+
+.panel p + p,
+.panel ul + p {
+    margin-top: 1rem;
+}
+
+.panel ul {
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.panel ul li {
+    padding-left: 1.4rem;
+    position: relative;
+}
+
+.panel ul li::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 0.55rem;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent-color);
+}
+
+.primary-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.85rem 1.6rem;
+    margin-top: 1.5rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, var(--accent-color), #4b5fc4);
+    color: #fff;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.primary-link::after {
+    content: "↗";
+    font-size: 1.2rem;
+}
+
+.media-grid {
+    display: grid;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+}
+
+.media-tile {
+    min-height: 220px;
+    border-radius: 24px;
+    background: linear-gradient(140deg, rgba(15, 30, 84, 0.14), rgba(15, 30, 84, 0.04));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(15, 30, 84, 0.75);
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+}
+
+.link-list {
+    list-style: none;
+    display: grid;
+    gap: 0.75rem;
+    margin-top: 1.2rem;
+}
+
+.link-list a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.65rem 1.2rem;
+    border-radius: 14px;
+    background: rgba(15, 30, 84, 0.08);
+    font-weight: 600;
+}
+
+.link-list a::after {
+    content: "↗";
+}
+
+.footer-note {
+    margin-top: 3.5rem;
+    text-align: center;
+    color: rgba(16, 16, 16, 0.6);
+    font-size: 0.85rem;
+}
+
+@media (max-width: 1024px) {
+    .drag-surface {
+        width: 1400px;
+        height: 1000px;
+    }
+
+    .home-hero {
+        width: min(90vw, 420px);
+    }
+
+    .project-card {
+        width: 240px;
+        min-height: 320px;
+    }
+}
+
+@media (max-width: 768px) {
+    .fixed-actions {
+        flex-direction: row;
+        bottom: 1.6rem;
+        top: auto;
+        left: 50%;
+        transform: translateX(-50%);
+    }
+
+    .menu-toggle {
+        top: auto;
+        bottom: 1.6rem;
+        left: 1.2rem;
+    }
+
+    .project-menu.is-open {
+        padding-top: 4.5rem;
+    }
+
+    .drag-surface {
+        width: 1100px;
+        height: 900px;
+    }
+
+    .project-card {
+        width: 210px;
+        min-height: 300px;
+    }
+
+    main.project-content {
+        padding-top: 6rem;
+    }
+
+    .fixed-actions {
+        gap: 0.6rem;
+    }
+}
+
+@media (max-width: 600px) {
+    .drag-hints {
+        font-size: 0.6rem;
+        letter-spacing: 0.18em;
+    }
+
+    .project-visual {
+        height: 140px;
+    }
+
+    .project-info {
+        padding: 1.4rem 1.4rem 1.2rem;
+    }
+
+    .project-header {
+        gap: 1.4rem;
+    }
+
+    .panel {
+        padding: 2rem;
+    }
+}

--- a/assets/docs/CV-Sebastien-Bouchard.pdf
+++ b/assets/docs/CV-Sebastien-Bouchard.pdf
@@ -1,0 +1,88 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 2617 >>
+stream
+BT
+/F1 20 Tf
+72 770 Td
+(SÉBASTIEN BOUCHARD) Tj
+/F1 12 Tf
+T* (Téléphone : 579 488-6866) Tj
+T* (Courriel : sebastienbouchard6@gmail.com) Tj
+T* (LinkedIn : linkedin.com/in/sébastien-bouchard-1329b321a) Tj
+/F1 16 Tf
+T* (SOMMAIRE) Tj
+/F1 11 Tf
+T* (Je vise à approfondir mon expertise en marketing, et chacune de mes implications est pensée dans ses axes.) Tj
+T* (Aujourd'hui, je cherche un environnement stimulant, axé sur l'apprentissage, ouvert et collaboratif,) Tj
+T* (où je peux apporter mon dynamisme, ma rigueur professionnelle et mettre en pratique mes compétences.) Tj
+T* (Ce qui me distingue : une grande capacité à évaluer rapidement une situation, à proposer des objectifs cohérents,) Tj
+T* (engageants et ancrés dans la réalité du terrain.) Tj
+/F1 16 Tf
+T* (EXPÉRIENCE) Tj
+/F1 12 Tf
+T* (Stagiaire en Marketing Numérique) Tj
+/F1 11 Tf
+T* (Agence Propulsion | Université de Sherbrooke | Novembre 2022 - Mai 2023) Tj
+T* (• Création d'expériences pour les campagnes publicitaires web de clients corporatifs.) Tj
+T* (• Analyse et recommandations sur la base de suivi et de conversion des leads.) Tj
+T* (• Collaboration avec les stratégistes pour aligner le contenu sur les objectifs d'affaires.) Tj
+/F1 12 Tf
+T* (Agent de communication) Tj
+/F1 11 Tf
+T* (Ville de Cowansville | Septembre 2021 - Août 2022) Tj
+T* (• Coordonner les activités de communication pour le lancement d'un centre sportif municipal.) Tj
+T* (• Gestion des médias sociaux et soutien aux demandes de la communauté.) Tj
+/F1 12 Tf
+T* (Conseiller à la vie étudiante) Tj
+/F1 11 Tf
+T* (Cégep de Granby | Août 2020 - Hiver 2023) Tj
+T* (• Organisation d'activités étudiantes et d'opérations de communication interne.) Tj
+/F1 16 Tf
+T* (FORMATION) Tj
+/F1 12 Tf
+T* (Baccalauréat en Administration des affaires - Marketing) Tj
+/F1 11 Tf
+T* (Université de Sherbrooke | 2021 - 2025 (prévision)) Tj
+T* (Cheminement coopératif | Bourses d'excellence | Focus marketing numérique) Tj
+/F1 12 Tf
+T* (Diplôme d'études collégiales - Gestion de commerces) Tj
+/F1 11 Tf
+T* (Cégep de Granby | 2018 - 2020) Tj
+T* (Mention au Tableau d'honneur | Prix MVP tournoi ESGR | Prix Coup de coeur du jury au HM) Tj
+/F1 16 Tf
+T* (IMPLICATIONS) Tj
+/F1 11 Tf
+T* (Comité d'optimisation du recrutement collégial | 2020 - 2022) Tj
+T* (Organisation des journées portes ouvertes, coordination d'une équipe de 12 ambassadeurs.) Tj
+T* (Animation de panels thématiques pour guider les futurs étudiants.) Tj
+T* (Cégep de Granby | 2018 - 2020) Tj
+T* (Organisation du bal des finissants, campagne de financement associative.) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000002909 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+2979
+%%EOF

--- a/assets/images/agence-propulsion-preview.svg
+++ b/assets/images/agence-propulsion-preview.svg
@@ -1,0 +1,19 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 400'>
+<defs>
+  <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+    <stop offset='0%' stop-color='#FF7C6E'/>
+    <stop offset='100%' stop-color='#FFC1B6'/>
+  </linearGradient>
+</defs>
+<rect width='600' height='400' fill='url(#grad)' rx='32'/>
+<g fill='white' font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-weight='600'>
+  <text x='48' y='210' font-size='48'>Agence Propulsion</text>
+  <text x='48' y='260' font-size='28' opacity='0.8'>Compétitions académiques</text>
+</g>
+<g stroke='white' stroke-width='3' stroke-linecap='round' opacity='0.65'>
+  <path d='M520 80 l40 0 0 40' fill='none'/>
+  <path d='M80 320 l-40 0 0 -40' fill='none'/>
+  <path d='M280 110 l40 -24' fill='none'/>
+  <path d='M300 330 l-60 28' fill='none'/>
+</g>
+</svg>

--- a/assets/images/asics-preview.svg
+++ b/assets/images/asics-preview.svg
@@ -1,0 +1,19 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 400'>
+<defs>
+  <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+    <stop offset='0%' stop-color='#4B5DF6'/>
+    <stop offset='100%' stop-color='#9AA9FF'/>
+  </linearGradient>
+</defs>
+<rect width='600' height='400' fill='url(#grad)' rx='32'/>
+<g fill='white' font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-weight='600'>
+  <text x='48' y='210' font-size='48'>ASICS</text>
+  <text x='48' y='260' font-size='28' opacity='0.8'>Marketing numérique</text>
+</g>
+<g stroke='white' stroke-width='3' stroke-linecap='round' opacity='0.65'>
+  <path d='M520 80 l40 0 0 40' fill='none'/>
+  <path d='M80 320 l-40 0 0 -40' fill='none'/>
+  <path d='M280 110 l40 -24' fill='none'/>
+  <path d='M300 330 l-60 28' fill='none'/>
+</g>
+</svg>

--- a/assets/images/brasser-preview.svg
+++ b/assets/images/brasser-preview.svg
@@ -1,0 +1,19 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 400'>
+<defs>
+  <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+    <stop offset='0%' stop-color='#FFB347'/>
+    <stop offset='100%' stop-color='#FF7B54'/>
+  </linearGradient>
+</defs>
+<rect width='600' height='400' fill='url(#grad)' rx='32'/>
+<g fill='white' font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-weight='600'>
+  <text x='48' y='210' font-size='48'>Brasser pour donner</text>
+  <text x='48' y='260' font-size='28' opacity='0.8'>Bière de microbrasserie</text>
+</g>
+<g stroke='white' stroke-width='3' stroke-linecap='round' opacity='0.65'>
+  <path d='M520 80 l40 0 0 40' fill='none'/>
+  <path d='M80 320 l-40 0 0 -40' fill='none'/>
+  <path d='M280 110 l40 -24' fill='none'/>
+  <path d='M300 330 l-60 28' fill='none'/>
+</g>
+</svg>

--- a/assets/images/cowansville-preview.svg
+++ b/assets/images/cowansville-preview.svg
@@ -1,0 +1,19 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 400'>
+<defs>
+  <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+    <stop offset='0%' stop-color='#33B3A6'/>
+    <stop offset='100%' stop-color='#8DE2D5'/>
+  </linearGradient>
+</defs>
+<rect width='600' height='400' fill='url(#grad)' rx='32'/>
+<g fill='white' font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-weight='600'>
+  <text x='48' y='210' font-size='48'>Cowansville Économique</text>
+  <text x='48' y='260' font-size='28' opacity='0.8'>Initiative locale</text>
+</g>
+<g stroke='white' stroke-width='3' stroke-linecap='round' opacity='0.65'>
+  <path d='M520 80 l40 0 0 40' fill='none'/>
+  <path d='M80 320 l-40 0 0 -40' fill='none'/>
+  <path d='M280 110 l40 -24' fill='none'/>
+  <path d='M300 330 l-60 28' fill='none'/>
+</g>
+</svg>

--- a/assets/images/familiprix-preview.svg
+++ b/assets/images/familiprix-preview.svg
@@ -1,0 +1,19 @@
+<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 600 400'>
+<defs>
+  <linearGradient id='grad' x1='0%' y1='0%' x2='100%' y2='100%'>
+    <stop offset='0%' stop-color='#6C63FF'/>
+    <stop offset='100%' stop-color='#B39DFF'/>
+  </linearGradient>
+</defs>
+<rect width='600' height='400' fill='url(#grad)' rx='32'/>
+<g fill='white' font-family="'Poppins', 'Helvetica Neue', Arial, sans-serif" font-weight='600'>
+  <text x='48' y='210' font-size='48'>Analyse Familiprix</text>
+  <text x='48' y='260' font-size='28' opacity='0.8'>Campagne santé</text>
+</g>
+<g stroke='white' stroke-width='3' stroke-linecap='round' opacity='0.65'>
+  <path d='M520 80 l40 0 0 40' fill='none'/>
+  <path d='M80 320 l-40 0 0 -40' fill='none'/>
+  <path d='M280 110 l40 -24' fill='none'/>
+  <path d='M300 330 l-60 28' fill='none'/>
+</g>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,88 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const menuToggle = document.querySelector('[data-menu-toggle]');
+    const menuPanel = document.querySelector('[data-project-menu]');
+    const menuLinks = menuPanel ? menuPanel.querySelectorAll('a') : [];
+
+    const toggleMenu = (force) => {
+        if (!menuPanel || !menuToggle) return;
+        const willOpen = typeof force === 'boolean' ? force : !menuPanel.classList.contains('is-open');
+        menuPanel.classList.toggle('is-open', willOpen);
+        menuToggle.setAttribute('aria-expanded', String(willOpen));
+        document.body.classList.toggle('menu-open', willOpen);
+    };
+
+    if (menuToggle) {
+        menuToggle.addEventListener('click', () => toggleMenu());
+    }
+
+    menuLinks.forEach((link) => {
+        link.addEventListener('click', () => toggleMenu(false));
+    });
+
+    document.addEventListener('keyup', (event) => {
+        if (event.key === 'Escape') {
+            toggleMenu(false);
+        }
+    });
+
+    const dragContainer = document.querySelector('[data-drag-container]');
+    const dragSurface = document.querySelector('[data-drag-surface]');
+
+    if (dragContainer && dragSurface) {
+        let isDragging = false;
+        let startX = 0;
+        let startY = 0;
+        const initialX = parseFloat(dragSurface.getAttribute('data-start-x')) || 0;
+        const initialY = parseFloat(dragSurface.getAttribute('data-start-y')) || 0;
+        const initialZoom = parseFloat(dragSurface.getAttribute('data-zoom')) || 1;
+        let currentX = initialX;
+        let currentY = initialY;
+
+        dragSurface.style.setProperty('--offset-x', `${currentX}px`);
+        dragSurface.style.setProperty('--offset-y', `${currentY}px`);
+        dragSurface.style.setProperty('--zoom', initialZoom);
+
+        const updatePosition = () => {
+            dragSurface.style.setProperty('--offset-x', `${currentX}px`);
+            dragSurface.style.setProperty('--offset-y', `${currentY}px`);
+        };
+
+        const pointerDown = (event) => {
+            if (event.button !== 0) return;
+            if (event.target.closest('a, button')) return;
+            isDragging = true;
+            dragContainer.classList.add('is-dragging');
+            startX = event.clientX - currentX;
+            startY = event.clientY - currentY;
+            event.preventDefault();
+            try {
+                dragContainer.setPointerCapture(event.pointerId);
+            } catch (error) {
+                // Ignore pointer capture errors (e.g., unsupported browser)
+            }
+        };
+
+        const pointerMove = (event) => {
+            if (!isDragging) return;
+            currentX = event.clientX - startX;
+            currentY = event.clientY - startY;
+            updatePosition();
+        };
+
+        const stopDragging = (event) => {
+            isDragging = false;
+            dragContainer.classList.remove('is-dragging');
+            try {
+                dragContainer.releasePointerCapture(event.pointerId);
+            } catch (error) {
+                // ignore release errors when pointer capture was not set
+            }
+        };
+
+        dragContainer.addEventListener('pointerdown', pointerDown);
+        dragContainer.addEventListener('pointermove', pointerMove);
+        dragContainer.addEventListener('pointerup', stopDragging);
+        dragContainer.addEventListener('pointerleave', stopDragging);
+        dragContainer.addEventListener('pointercancel', stopDragging);
+    }
+});

--- a/brasser-pour-donner.html
+++ b/brasser-pour-donner.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Brasser pour donner – Commercialisation</title>
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="project-page">
+    <button class="menu-toggle hover-scale" type="button" data-menu-toggle aria-expanded="false" aria-controls="project-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span>Menu</span>
+    </button>
+
+    <nav class="project-menu" id="project-menu" data-project-menu>
+        <ul>
+            <li><a class="hover-scale" href="index.html">Accueil</a></li>
+            <li><a class="hover-scale" href="asics.html">Asics – Stratégie numérique</a></li>
+            <li><a class="hover-scale" href="agence-propulsion.html">Agence Propulsion – Compétitions académiques</a></li>
+            <li><a class="hover-scale" href="cowansville-economique.html">Cowansville Économique – Lancement d’initiative</a></li>
+            <li><a class="hover-scale" href="brasser-pour-donner.html">Brasser pour donner – Commercialisation</a></li>
+            <li><a class="hover-scale" href="analyse-familiprix.html">Analyse Familiprix – Campagne publicitaire</a></li>
+        </ul>
+    </nav>
+
+    <div class="fixed-actions">
+        <a class="action-link hover-scale" href="assets/docs/CV-Sebastien-Bouchard.pdf" target="_blank" rel="noopener">CV</a>
+        <a class="action-link hover-scale" href="https://www.instagram.com/seb_bouch33/" target="_blank" rel="noopener">Instagram</a>
+        <a class="action-link hover-scale" href="https://www.linkedin.com/in/s%C3%A9bastien-bouchard-1329b321a/" target="_blank" rel="noopener">LinkedIn</a>
+    </div>
+
+    <main class="project-content">
+        <header class="project-header">
+            <div>
+                <span class="tag">Marketing de produit</span>
+                <h1>Brasser pour donner</h1>
+                <p class="lead">Projet annuel du Cégep de Granby visant à commercialiser une bière en microbrasserie au profit d’organismes de la région. Mon rôle : orchestrer la stratégie de mise en marché, la narration de marque et les partenariats médias.</p>
+            </div>
+            <div class="project-meta">
+                <span class="tag">Branding</span>
+                <span class="tag">Expérience</span>
+                <span class="tag">Partenariats</span>
+            </div>
+        </header>
+
+        <section class="project-panels">
+            <article class="panel">
+                <h2>Identité &amp; storytelling</h2>
+                <p>Développement de l’identité visuelle Session Panorama en collaboration avec les étudiants en design. Le storytelling met de l’avant la contribution communautaire ainsi que la mise en valeur des producteurs locaux.</p>
+                <div class="media-grid">
+                    <div class="media-tile hover-scale">Charte visuelle</div>
+                    <div class="media-tile hover-scale">Design d’étiquette</div>
+                    <div class="media-tile hover-scale">Borne événementielle</div>
+                </div>
+            </article>
+
+            <article class="panel">
+                <h2>Stratégie de distribution</h2>
+                <p>Plan de distribution en phases pour optimiser la présence en points de vente et assurer un suivi logistique rigoureux.</p>
+                <ul>
+                    <li>Lancement VIP auprès des partenaires régionaux.</li>
+                    <li>Pop-up expérientiels dans les établissements participants.</li>
+                    <li>Campagnes sociales présentant les retombées pour l’organisme bénéficiaire.</li>
+                </ul>
+            </article>
+
+            <article class="panel">
+                <h2>Couverture médiatique</h2>
+                <p>Les médias régionaux ont relayé l’histoire de la Session Panorama et l’impact du projet pour la communauté.</p>
+                <ul class="link-list">
+                    <li><a class="hover-scale" href="https://www.facebook.com/brasserpourdonnertf/videos/2143124829470987" target="_blank" rel="noopener">Vidéo – Facebook</a></li>
+                    <li><a class="hover-scale" href="https://www.facebook.com/reel/2654720142525644" target="_blank" rel="noopener">Reportage – Facebook</a></li>
+                </ul>
+            </article>
+        </section>
+
+        <p class="footer-note">Projet réalisé en collaboration avec l’organisme Brasser pour donner – remerciements aux partenaires locaux.</p>
+    </main>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/cowansville-economique.html
+++ b/cowansville-economique.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cowansville Économique – Plan marketing</title>
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body class="project-page">
+    <button class="menu-toggle hover-scale" type="button" data-menu-toggle aria-expanded="false" aria-controls="project-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span>Menu</span>
+    </button>
+
+    <nav class="project-menu" id="project-menu" data-project-menu>
+        <ul>
+            <li><a class="hover-scale" href="index.html">Accueil</a></li>
+            <li><a class="hover-scale" href="asics.html">Asics – Stratégie numérique</a></li>
+            <li><a class="hover-scale" href="agence-propulsion.html">Agence Propulsion – Compétitions académiques</a></li>
+            <li><a class="hover-scale" href="cowansville-economique.html">Cowansville Économique – Lancement d’initiative</a></li>
+            <li><a class="hover-scale" href="brasser-pour-donner.html">Brasser pour donner – Commercialisation</a></li>
+            <li><a class="hover-scale" href="analyse-familiprix.html">Analyse Familiprix – Campagne publicitaire</a></li>
+        </ul>
+    </nav>
+
+    <div class="fixed-actions">
+        <a class="action-link hover-scale" href="assets/docs/CV-Sebastien-Bouchard.pdf" target="_blank" rel="noopener">CV</a>
+        <a class="action-link hover-scale" href="https://www.instagram.com/seb_bouch33/" target="_blank" rel="noopener">Instagram</a>
+        <a class="action-link hover-scale" href="https://www.linkedin.com/in/s%C3%A9bastien-bouchard-1329b321a/" target="_blank" rel="noopener">LinkedIn</a>
+    </div>
+
+    <main class="project-content">
+        <header class="project-header">
+            <div>
+                <span class="tag">Développement économique</span>
+                <h1>Cowansville Économique</h1>
+                <p class="lead">Plan marketing complet pour soutenir le lancement d’une initiative économique municipale. Objectif : positionner Cowansville comme un partenaire incontournable pour les entreprises émergentes de la région.</p>
+            </div>
+            <div class="project-meta">
+                <span class="tag">Recherche terrain</span>
+                <span class="tag">Planification</span>
+                <span class="tag">Activation locale</span>
+            </div>
+        </header>
+
+        <section class="project-panels">
+            <article class="panel">
+                <h2>Analyse de marché</h2>
+                <p>Inventaire complet des services offerts par la municipalité et identification des écarts concurrentiels. Cette analyse a permis de prioriser les segments à fort potentiel, notamment les entreprises en croissance et les organisations d’économie sociale.</p>
+                <ul>
+                    <li>Veille concurrentielle sur les villes comparables.</li>
+                    <li>Ateliers de co-création avec les équipes municipales.</li>
+                    <li>Diagnostic de la marque employeur et des communications existantes.</li>
+                </ul>
+                <div class="media-grid">
+                    <div class="media-tile hover-scale">Cartographie des services</div>
+                    <div class="media-tile hover-scale">Analyse comparative</div>
+                </div>
+            </article>
+
+            <article class="panel">
+                <h2>Stratégie de lancement</h2>
+                <p>Déploiement en trois phases pour accroître la notoriété, convertir les entreprises ciblées et fidéliser l’écosystème entrepreneurial.</p>
+                <ul>
+                    <li>Phase 1 – Sensibilisation par relations publiques et contenu vidéo.</li>
+                    <li>Phase 2 – Tournée d’ateliers et outils d’accompagnement personnalisés.</li>
+                    <li>Phase 3 – Plateforme numérique de services avec segmentation par besoins.</li>
+                </ul>
+            </article>
+
+            <article class="panel">
+                <h2>Couverture médiatique</h2>
+                <p>Des retombées médiatiques locales et régionales ont soutenu le positionnement de l’initiative. Les liens seront mis à jour à mesure que de nouvelles parutions seront disponibles.</p>
+                <ul class="link-list">
+                    <li><a class="hover-scale" href="https://example.com/couverture-cowansville-1" target="_blank" rel="noopener">Article – Lancement officiel</a></li>
+                    <li><a class="hover-scale" href="https://example.com/couverture-cowansville-2" target="_blank" rel="noopener">Chronique – Partenaires économiques</a></li>
+                    <li><a class="hover-scale" href="https://example.com/couverture-cowansville-3" target="_blank" rel="noopener">Entrevue – Vision municipale</a></li>
+                </ul>
+                <a class="primary-link hover-scale" href="https://example.com/cowansville-projet-detaille.pdf" target="_blank" rel="noopener">Projet détaillé</a>
+            </article>
+        </section>
+
+        <p class="footer-note">Plan marketing produit pour la Ville de Cowansville – documentation confidentielle disponible sur demande.</p>
+    </main>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,355 +1,97 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Portfolio - Sébastien Bouchard</title>
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-
-        body {
-            font-family: 'Arial', sans-serif;
-            background: #f8f8f8;
-            overflow-x: hidden;
-            cursor: crosshair;
-            height: 100vh;
-        }
-
-        .viewport-container {
-            position: relative;
-            width: 100vw;
-            height: 100vh;
-            overflow: hidden;
-        }
-
-        /* Header with name */
-        .header {
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            text-align: center;
-            z-index: 10;
-        }
-
-        .name {
-            font-size: clamp(3rem, 8vw, 8rem);
-            font-weight: 900;
-            letter-spacing: -0.02em;
-            color: #2c2c2c;
-            margin-bottom: 1rem;
-        }
-
-        .tagline {
-            font-size: clamp(0.9rem, 2vw, 1.2rem);
-            color: #666;
-            font-weight: 300;
-            text-transform: uppercase;
-            letter-spacing: 0.15em;
-            margin-bottom: 2rem;
-        }
-
-        /* Floating elements */
-        .floating-element {
-            position: absolute;
-            background: white;
-            box-shadow: 0 10px 40px rgba(0,0,0,0.1);
-            transition: all 0.3s ease;
-            cursor: pointer;
-            border-radius: 2px;
-        }
-
-        .floating-element:hover {
-            transform: scale(1.05);
-            box-shadow: 0 20px 60px rgba(0,0,0,0.15);
-            z-index: 100;
-        }
-
-        /* Menu button */
-        .menu-btn {
-            top: 15%;
-            left: 45%;
-            width: 120px;
-            height: 50px;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            background: #2c2c2c;
-            color: white;
-        }
-
-        .menu-btn .hamburger {
-            width: 25px;
-            height: 3px;
-            background: white;
-            position: relative;
-            margin-right: 10px;
-        }
-
-        .menu-btn .hamburger::before,
-        .menu-btn .hamburger::after {
-            content: '';
-            position: absolute;
-            width: 25px;
-            height: 3px;
-            background: white;
-            left: 0;
-        }
-
-        .menu-btn .hamburger::before {
-            top: -8px;
-        }
-
-        .menu-btn .hamburger::after {
-            top: 8px;
-        }
-
-        /* Projects section */
-        .projects-btn {
-            top: 20%;
-            right: 8%;
-            width: 160px;
-            height: 70px;
-            background: #4a90e2;
-            color: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 1.1rem;
-            font-weight: 600;
-        }
-
-        /* Image blocks */
-        .image-block {
-            background: #ddd;
-            background-size: cover;
-            background-position: center;
-        }
-
-        .image-block-1 {
-            top: 8%;
-            left: 8%;
-            width: 150px;
-            height: 120px;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-        }
-
-        .image-block-2 {
-            top: 75%;
-            left: 12%;
-            width: 130px;
-            height: 180px;
-            background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
-        }
-
-        .image-block-3 {
-            top: 25%;
-            right: 15%;
-            width: 140px;
-            height: 100px;
-            background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
-        }
-
-        .image-block-4 {
-            bottom: 15%;
-            right: 25%;
-            width: 120px;
-            height: 120px;
-            background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
-        }
-
-        .image-block-5 {
-            bottom: 8%;
-            left: 35%;
-            width: 110px;
-            height: 140px;
-            background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
-        }
-
-        .image-block-6 {
-            top: 6%;
-            right: 30%;
-            width: 100px;
-            height: 80px;
-            background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
-        }
-
-        .image-block-7 {
-            bottom: 8%;
-            right: 8%;
-            width: 160px;
-            height: 90px;
-            background: linear-gradient(135deg, #ff9a9e 0%, #fecfef 100%);
-        }
-
-        /* Text blocks */
-        .text-block {
-            padding: 20px;
-            background: white;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            text-align: center;
-            font-size: 0.85rem;
-            font-weight: 500;
-            color: #333;
-        }
-
-        .contact-block {
-            top: 25%;
-            left: 20%;
-            width: 150px;
-            height: 60px;
-            background: #2c2c2c;
-            color: white;
-        }
-
-        /* Navigation indicator */
-        .nav-indicator {
-            position: absolute;
-            bottom: 50px;
-            left: 50%;
-            transform: translateX(-50%);
-            width: 40px;
-            height: 40px;
-            cursor: pointer;
-        }
-
-        .nav-indicator::before,
-        .nav-indicator::after {
-            content: '';
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            width: 20px;
-            height: 2px;
-            background: #666;
-        }
-
-        .nav-indicator::before {
-            transform: translate(-50%, -50%) rotate(45deg);
-        }
-
-        .nav-indicator::after {
-            transform: translate(-50%, -50%) rotate(-45deg);
-        }
-
-        /* Responsive adjustments */
-        @media (max-width: 768px) {
-            .floating-element {
-                transform: scale(0.8);
-            }
-            
-            .name {
-                font-size: 4rem;
-            }
-            
-            .tagline {
-                font-size: 0.9rem;
-            }
-        }
-
-        /* Smooth animations */
-        @keyframes float {
-            0%, 100% { transform: translateY(0px) rotate(0deg); }
-            33% { transform: translateY(-10px) rotate(1deg); }
-            66% { transform: translateY(5px) rotate(-1deg); }
-        }
-
-        .floating-element:nth-child(odd) {
-            animation: float 6s ease-in-out infinite;
-        }
-
-        .floating-element:nth-child(even) {
-            animation: float 8s ease-in-out infinite reverse;
-        }
-    </style>
+    <title>Portfolio Marketing – Sébastien Bouchard</title>
+    <link rel="stylesheet" href="assets/css/styles.css">
 </head>
-<body>
-    <div class="viewport-container">
-        <!-- Main Header -->
-        <div class="header">
-            <h1 class="name">SÉBASTIEN BOUCHARD</h1>
-            <p class="tagline">Portfolio Marketing</p>
-        </div>
+<body class="home">
+    <button class="menu-toggle hover-scale" type="button" data-menu-toggle aria-expanded="false" aria-controls="project-menu">
+        <span class="menu-icon" aria-hidden="true"></span>
+        <span>Menu</span>
+    </button>
 
-        <!-- Menu Button -->
-        <div class="floating-element menu-btn" onclick="showMenu()">
-            <div class="hamburger"></div>
-            <span>MENU</span>
-        </div>
+    <nav class="project-menu" id="project-menu" data-project-menu>
+        <ul>
+            <li><a class="hover-scale" href="index.html">Accueil</a></li>
+            <li><a class="hover-scale" href="asics.html">Asics – Stratégie numérique</a></li>
+            <li><a class="hover-scale" href="agence-propulsion.html">Agence Propulsion – Compétitions académiques</a></li>
+            <li><a class="hover-scale" href="cowansville-economique.html">Cowansville Économique – Lancement d’initiative</a></li>
+            <li><a class="hover-scale" href="brasser-pour-donner.html">Brasser pour donner – Commercialisation</a></li>
+            <li><a class="hover-scale" href="analyse-familiprix.html">Analyse Familiprix – Campagne publicitaire</a></li>
+        </ul>
+    </nav>
 
-        <!-- Projects Button -->
-        <div class="floating-element projects-btn" onclick="showProjects()">
-            PROJETS
-        </div>
-
-        <!-- Image Blocks (representing portfolio pieces) -->
-        <div class="floating-element image-block image-block-1" onclick="openProject(1)"></div>
-        <div class="floating-element image-block image-block-2" onclick="openProject(2)"></div>
-        <div class="floating-element image-block image-block-3" onclick="openProject(3)"></div>
-        <div class="floating-element image-block image-block-4" onclick="openProject(4)"></div>
-        <div class="floating-element image-block image-block-5" onclick="openProject(5)"></div>
-        <div class="floating-element image-block image-block-6" onclick="openProject(6)"></div>
-        <div class="floating-element image-block image-block-7" onclick="openProject(7)"></div>
-
-        <!-- Contact Block -->
-        <div class="floating-element text-block contact-block" onclick="showContact()">
-            CONTACT
-        </div>
-
-        <!-- Navigation Indicator -->
-        <div class="nav-indicator" onclick="scrollDown()"></div>
+    <div class="fixed-actions">
+        <a class="action-link hover-scale" href="assets/docs/CV-Sebastien-Bouchard.pdf" target="_blank" rel="noopener">CV</a>
+        <a class="action-link hover-scale" href="https://www.instagram.com/seb_bouch33/" target="_blank" rel="noopener">Instagram</a>
+        <a class="action-link hover-scale" href="https://www.linkedin.com/in/s%C3%A9bastien-bouchard-1329b321a/" target="_blank" rel="noopener">LinkedIn</a>
     </div>
 
-    <script>
-        // Add interactive functionality
-        function showMenu() {
-            alert('Fonctionnalité menu - vous pouvez développer ceci pour afficher les options de navigation');
-        }
+    <main class="drag-container" data-drag-container>
+        <div class="drag-hints" aria-hidden="true">
+            <span class="hint hint-up">Glisser</span>
+            <span class="hint hint-right">Glisser</span>
+            <span class="hint hint-down">Glisser</span>
+            <span class="hint hint-left">Glisser</span>
+        </div>
+        <div class="drag-surface" data-drag-surface data-start-x="-160" data-start-y="-120" data-zoom="1.25">
+            <section class="home-hero hover-scale">
+                <h1>Sébastien Bouchard</h1>
+                <p>Portfolio</p>
+            </section>
 
-        function showProjects() {
-            alert('Section projets - présentez votre travail ici');
-        }
+            <div class="projects-cloud">
+                <a class="project-card hover-scale" data-project="asics" href="asics.html">
+                    <figure class="project-visual">
+                        <img src="assets/images/asics-preview.svg" alt="Aperçu du mandat marketing numérique ASICS">
+                    </figure>
+                    <div class="project-info">
+                        <h2>ASICS</h2>
+                        <p>Marketing numérique (Analyse et recommandations)</p>
+                    </div>
+                </a>
+                <a class="project-card hover-scale" data-project="agence-propulsion" href="agence-propulsion.html">
+                    <figure class="project-visual">
+                        <img src="assets/images/agence-propulsion-preview.svg" alt="Aperçu des compétitions académiques de l’Agence Propulsion">
+                    </figure>
+                    <div class="project-info">
+                        <h2>Agence Propulsion</h2>
+                        <p>Agence des compétitions académiques</p>
+                    </div>
+                </a>
+                <a class="project-card hover-scale" data-project="cowansville" href="cowansville-economique.html">
+                    <figure class="project-visual">
+                        <img src="assets/images/cowansville-preview.svg" alt="Aperçu de la stratégie marketing de Cowansville Économique">
+                    </figure>
+                    <div class="project-info">
+                        <h2>Cowansville Économique</h2>
+                        <p>Stratégie marketing complète pour le déploiement d’une initiative économique</p>
+                    </div>
+                </a>
+                <a class="project-card hover-scale" data-project="brasser" href="brasser-pour-donner.html">
+                    <figure class="project-visual">
+                        <img src="assets/images/brasser-preview.svg" alt="Aperçu de la campagne Brasser pour donner">
+                    </figure>
+                    <div class="project-info">
+                        <h2>Brasser pour donner</h2>
+                        <p>Commercialisation d’une bière de microbrasserie</p>
+                    </div>
+                </a>
+                <a class="project-card hover-scale" data-project="familiprix" href="analyse-familiprix.html">
+                    <figure class="project-visual">
+                        <img src="assets/images/familiprix-preview.svg" alt="Aperçu du projet Ne cherchez pas vos symptômes sur Internet">
+                    </figure>
+                    <div class="project-info">
+                        <h2>Analyse Familiprix</h2>
+                        <p>Ne cherchez pas vos symptômes sur Internet (Familiprix)</p>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </main>
 
-        function openProject(id) {
-            alert(`Ouverture du projet ${id} - vous pouvez lier vers des pages de projet détaillées`);
-        }
-
-        function showContact() {
-            alert('Informations de contact - ajoutez votre email, liens sociaux, etc.');
-        }
-
-        function scrollDown() {
-            alert('Ajoutez des sections supplémentaires ou une fonctionnalité de défilement fluide');
-        }
-
-        // Add some interactivity on mouse move
-        document.addEventListener('mousemove', (e) => {
-            const elements = document.querySelectorAll('.floating-element');
-            const mouseX = e.clientX / window.innerWidth;
-            const mouseY = e.clientY / window.innerHeight;
-            
-            elements.forEach((element, index) => {
-                const speed = (index % 3 + 1) * 0.5;
-                const x = (mouseX - 0.5) * speed;
-                const y = (mouseY - 0.5) * speed;
-                
-                element.style.transform += ` translate(${x}px, ${y}px)`;
-            });
-        });
-
-        // Reset positions periodically
-        setInterval(() => {
-            const elements = document.querySelectorAll('.floating-element');
-            elements.forEach(element => {
-                element.style.transform = element.style.transform.replace(/translate\([^)]*\)/g, '');
-            });
-        }, 3000);
-    </script>
+    <script src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the placeholder homepage with a draggable marketing portfolio canvas featuring fixed social/menu controls, on-canvas arrow hints, and image-led project cards that reveal fully when dragged
- add dedicated HTML pages for each project with consistent styling, interactive hover states, and placeholder links to PDFs
- centralize shared styling and behaviour in reusable CSS and JavaScript assets for menu toggling and drag navigation
- add a local CV PDF asset and point every CV action to it
- create custom SVG preview artwork for each homepage project tile

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cb28da465c8326a80225a346c2ca1c